### PR TITLE
Fixed delay uses Interrupts, that are not setup during construction

### DIFF
--- a/Cubetto.h
+++ b/Cubetto.h
@@ -91,62 +91,62 @@ AccelStepper rightStepper(AccelStepper::HALF4WIRE, PRIMO_RIGHT_STEPPER_PIN_1, PR
 	    void playHappyTune()
 		{
 		  tone(PRIMO_BUZZER_PIN, PRIMO_NOTE_C6);
-		  delay(150);
+		  delayMicroseconds(150 * 1000);
 		  tone(PRIMO_BUZZER_PIN, PRIMO_NOTE_E6);
-		  delay(150);
+		  delayMicroseconds(150 * 1000);
 		  tone(PRIMO_BUZZER_PIN, PRIMO_NOTE_G6);
-		  delay(100);
+		  delayMicroseconds(100 * 1000);
 		  noTone(PRIMO_BUZZER_PIN);
 		}
 
 		void playSadTune()
 		{
 		  tone(PRIMO_BUZZER_PIN, PRIMO_NOTE_G5);
-		  delay(150);
+		  delayMicroseconds(150 * 1000);
 		  tone(PRIMO_BUZZER_PIN, PRIMO_NOTE_DS5);
-		  delay(150);
+		  delayMicroseconds(150 * 1000);
 		  tone(PRIMO_BUZZER_PIN, PRIMO_NOTE_C5);
-		  delay(300);
+		  delayMicroseconds(300 * 1000);
 		  noTone(PRIMO_BUZZER_PIN);
 		}
 
 		void playPairedTune()
 		{
 		  tone(PRIMO_BUZZER_PIN, PRIMO_NOTE_D6);
-		  delay(150);
+		  delayMicroseconds(150 * 1000);
 		  tone(PRIMO_BUZZER_PIN, PRIMO_NOTE_F6);
-		  delay(150);
+		  delayMicroseconds(150 * 1000);
 		  tone(PRIMO_BUZZER_PIN, PRIMO_NOTE_DS5);
-		  delay(100);
+		  delayMicroseconds(100 * 1000);
 		  noTone(PRIMO_BUZZER_PIN);
 		}
 
 		void playUnpairedTune()
 		{
 		  tone(PRIMO_BUZZER_PIN, PRIMO_NOTE_G3);
-		  delay(250);
+		  delayMicroseconds(250 * 1000);
 		  tone(PRIMO_BUZZER_PIN, PRIMO_NOTE_F3);
-		  delay(250);
+		  delayMicroseconds(250 * 1000);
 		  tone(PRIMO_BUZZER_PIN, PRIMO_NOTE_B2);
-		  delay(300);
+		  delayMicroseconds(300 * 1000);
 		  noTone(PRIMO_BUZZER_PIN);
 		}
 
 		void playForwardTune() {
 		  tone(PRIMO_BUZZER_PIN, 3000);
-		  delay(50);
+		  delayMicroseconds(50 * 1000);
 		  noTone(PRIMO_BUZZER_PIN);
 		}
 
 		void playLeftTune() {
 		  tone(PRIMO_BUZZER_PIN, 5000);
-		  delay(50);
+		  delayMicroseconds(50 * 1000);
 		  noTone(PRIMO_BUZZER_PIN);
 		}
 
 		void playRightTune() {
 		  tone(PRIMO_BUZZER_PIN, 4000);
-		  delay(50);
+		  delayMicroseconds(50 * 1000);
 		  noTone(PRIMO_BUZZER_PIN);
 		}
 


### PR DESCRIPTION
During construction time, the function `delay` cannot be used (The Play tone was in fact bugging the code).

So, I changed to `delayMicrosseconds` that doesn't depends on Timers or anything (and can even be called from within Interrupts).

This way is even better, because if someone wants to "perform" tasks within a Timer or interrupt, the `playTone` will always work.
